### PR TITLE
fix: missing return type for del

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -4,7 +4,7 @@ declare const isVue3: boolean
 declare const install: (vue?: any) => void
 
 export function set<T>(target: any, key: any, val: T): T
-export function del(target: any, key: any)
+export function del(target: any, key: any): void
 
 export * from 'vue'
 export {


### PR DESCRIPTION
Hey,

I'm getting `node_modules/villus/node_modules/vue-demi/lib/index.d.ts(7,17): error TS7010: 'del', which lacks return-type annotation, implicitly has an 'any' return type.` error when I run `tsc`. I have a `vue 3` project which uses `@vueuse/core`.

Besides, `lib/v3/index.d.ts` already specifies `: void` as return type.

This change should fix `tsc` error.