### PR TITLE
fix(lib/v2): edge case for vue-demi, vue2 and cjs

### DIFF
--- a/lib/v2/index.cjs.js
+++ b/lib/v2/index.cjs.js
@@ -2,12 +2,16 @@ var Vue = require('vue')
 var VueCompositionAPI = require('@vue/composition-api')
 
 function install(_vue) {
-  _vue = _vue || Vue
-  if (_vue && !_vue['__composition_api_installed__']) {
+  var vueLib = _vue || Vue
+  if (vueLib && 'default' in vueLib) {
+    vueLib = vueLib.default
+  }
+
+  if (vueLib && !vueLib['__composition_api_installed__']) {
     if (VueCompositionAPI && 'default' in VueCompositionAPI)
-      _vue.use(VueCompositionAPI.default)
+      vueLib.use(VueCompositionAPI.default)
     else if (VueCompositionAPI)
-      _vue.use(VueCompositionAPI)
+      vueLib.use(VueCompositionAPI)
   }
 }
 


### PR DESCRIPTION
Support edge case for VueDemi + Vue2 + CJS where `vue` has a default export which should be used to access `vue.use`

Closes: https://github.com/vueuse/vue-demi/issues/62