### PR TITLE
fix: don't expose incorrect ESM entry in `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,7 @@
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",
   "exports": {
-    ".": {
-      "import": "./lib/index.esm.js",
-      "require": "./lib/index.cjs.js"
-    },
+    ".": "./lib/index.cjs.js",
     "./*": "./*"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,11 @@
   "module": "lib/index.esm.js",
   "types": "lib/index.d.ts",
   "exports": {
-    ".": "./lib/index.cjs.js",
+    ".": {
+      "require": "./lib/index.cjs.js",
+      "node": "./lib/index.cjs.js",
+      "browser": "./lib/index.esm.js"
+    },
     "./*": "./*"
   },
   "bin": {


### PR DESCRIPTION
Fixes #66.

Node.js sees `.js` files as CJS modules if there's no `type: "module"` in `package.json`. So `index.esm.js` can't be imported from ES modules.

However, CJS modules can be imported from ES modules, named exports are also supported if it is statically analyzable.
So simply removing the `import` field should be just fine.

The `module` field is only used by bundlers, so keeping `.js` extension is harmless.

---

A better fix would be using a proper `.mjs` extension for the ESM build. But I haven't investigated #63, so I chose the safer approach.