### PR TITLE
docs: add vue-word-highlighter to "who are using this"

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ See [examples](./examples).
 - [vue-tiny-validate](https://github.com/FrontLabsOfficial/vue-tiny-validate) - Tiny Vue Validate Composition
 - [v-perfect-signature](https://github.com/wobsoriano/v-perfect-signature) - Pressure-sensitive signature drawing for Vue 2 and 3
 - [vue-winbox](https://github.com/wobsoriano/vue-winbox) - A wrapper component for WinBox.js that adds the ability to mount Vue components.
+- [vue-word-highlighter](https://github.com/kawamataryo/vue-word-highlighter) - The word highlighter library for Vue 2 and Vue 3
 
 > open a PR to add your library ;)
 


### PR DESCRIPTION
Thanks for the very useful library.
 I've created a package that uses this library and added it to "who are using this".