### PR TITLE
chore: add unstable vue version to peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@vue/composition-api": "^1.0.0-rc.1",
-    "vue": "^3.0.0 || ^2.6.0"
+    "vue": "^3.0.0-0 || ^2.6.0"
   },
   "peerDependenciesMeta": {
     "@vue/composition-api": {


### PR DESCRIPTION
<img width="840" alt="Screenshot 2021-08-06 at 15 01 05" src="https://user-images.githubusercontent.com/664177/128514146-610b9313-af01-4fa2-8de1-b13f9bb2f970.png">

This should allow using the beta versions of Vue without issuing a warning. Note I haven't been able to test it locally but in terms of semver it should work