### PR TITLE
chore: enable importing module in node

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "exports": {
     ".": {
       "require": "./lib/index.cjs",
-      "node": "./lib/index.cjs",
       "import": "./lib/index.mjs",
       "browser": "./lib/index.mjs"
     },


### PR DESCRIPTION
This line was originally added by https://github.com/vueuse/vue-demi/pull/70 (at which point there were no `mjs`/`cjs` files).

Now that there are, this line is now preventing importing the `.mjs` file from within a module context in node.

The error generated is:
```
import { isRef, ref, watchEffect, computed, customRef, unref, inject, watch, getCurrentInstance, onMounted, onUpdated, shallowRef, getCurrentScope, reactive, markRaw, readonly, onBeforeUpdate, isVue2 } from 'vue-demi';
                ^^^
SyntaxError: Named export 'ref' not found. The requested module 'vue-demi' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'vue-demi';
const { isRef, ref, watchEffect, computed, customRef, unref, inject, watch, getCurrentInstance, onMounted, onUpdated, shallowRef, getCurrentScope, reactive, markRaw, readonly, onBeforeUpdate, isVue2 } = pkg;
```