### PR TITLE
import .mjs version of vue-composition-api

### DIFF
--- a/lib/v2/index.mjs
+++ b/lib/v2/index.mjs
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import VueCompositionAPI from '@vue/composition-api/dist/vue-composition-api.esm.js'
+import VueCompositionAPI from '@vue/composition-api/dist/vue-composition-api.mjs'
 
 function install(_vue) {
   _vue = _vue || Vue
@@ -15,7 +15,7 @@ var Vue2 = Vue
 var version = Vue.version
 
 /**VCA-EXPORTS**/
-export * from '@vue/composition-api/dist/vue-composition-api.esm.js'
+export * from '@vue/composition-api/dist/vue-composition-api.mjs'
 /**VCA-EXPORTS**/
 
 export {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -40,7 +40,7 @@ function updateVue2API() {
   content = content.replace(
     /\/\*\*VCA-EXPORTS\*\*\/[\s\S]+\/\*\*VCA-EXPORTS\*\*\//m,
 `/**VCA-EXPORTS**/
-export { ${exports.join(', ')} } from '@vue/composition-api/dist/vue-composition-api.esm.js'
+export { ${exports.join(', ')} } from '@vue/composition-api/dist/vue-composition-api.mjs'
 /**VCA-EXPORTS**/`
     )
 


### PR DESCRIPTION
I do not know if this is a good solution in general, but it fixed the build for us.

After upgrading `@vue/composition-api` our own code was importing `vue-composition-api.mjs` into the bundle, but `@vueuse/core` via `vue-demi` imported `vue-composition-api.esm.js`. This bundling of two different modules lead to the `[vue-composition-api] must call Vue.use(VueCompositionAPI)` error.