### PR TITLE
feat(types): better compatibility

### DIFF
--- a/lib/v2/index.d.ts
+++ b/lib/v2/index.d.ts
@@ -1,15 +1,25 @@
 import Vue from 'vue'
+import type { PluginFunction, PluginObject } from 'vue'
 declare const isVue2: boolean
 declare const isVue3: boolean
 declare const Vue2: Vue | undefined
 declare const version: string
 declare const install: (vue?: Vue) => void
-/** 
+/**
  * @deprecated To avoid bringing in all the tree-shakable modules, this API has been deprecated. Use `Vue2` or named exports instead.
  * Refer to https://github.com/vueuse/vue-demi/issues/41
  */
 declare const V: Vue
 
+/**
+ * DebuggerEvent is a Vue 3 development only feature. This type cannot exist in Vue 2.
+ */
+export declare type DebuggerEvent = never
+
+// accept no generic because Vue 3 doesn't accept any
+// https://github.com/vuejs/vue-next/pull/2758/
+export declare type Plugin = PluginObject<any> | PluginFunction<any>
+export type { VNode } from 'vue'
 export * from '@vue/composition-api'
 export {
   V as Vue,


### PR DESCRIPTION
I think It would make sense to expose `DebuggerEvent`, `VNode`, and `Plugin` types to make them compatible with Vue 3. I'm not sure if types should be exposed individually or if there should be an `export *`.

Other types that I think should be added:

- ComponentCustomProps
- AllowedComponentProps
- VNodeProps

There are useful for solar:

```ts
// example from vue-router-next (which doesn't require this as it is Vue 3 only)
export const RouterView = RouterViewImpl as unknown as {
  new (): {
    $props: AllowedComponentProps &
      ComponentCustomProps &
      VNodeProps &
      RouterViewProps

    $slots: {
      default: (arg: {
        Component: VNode
        route: RouteLocationNormalizedLoaded
      }) => VNode[]
    }
  }
}
```