### PR TITLE
fix(iife): support no-window environments

### DIFF
--- a/lib/index.iife.js
+++ b/lib/index.iife.js
@@ -1,12 +1,9 @@
-;(function (window) {
-  if (window.VueDemi) {
-    return
+;var VueDemi = (function (VueDemi, Vue, VueCompositionAPI) {
+  if (VueDemi) {
+    return VueDemi
   }
-  var VueDemi = {}
-  var Vue = window.Vue
   if (Vue) {
     if (Vue.version.slice(0, 2) === '2.') {
-      var VueCompositionAPI = window.VueCompositionAPI
       if (VueCompositionAPI) {
         for (var key in VueCompositionAPI) {
           VueDemi[key] = VueCompositionAPI[key]
@@ -56,5 +53,9 @@
       '[vue-demi] no Vue instance found, please be sure to import `vue` before `vue-demi`.'
     )
   }
-  window.VueDemi = VueDemi
-})(window)
+  return VueDemi
+})(
+  this.VueDemi = this.VueDemi || VueDemi || {},
+  this.Vue || Vue,
+  this.VueCompositionAPI || VueCompositionAPI
+);


### PR DESCRIPTION
Add support for environments without a `window` in the iife version, which is supported by Vue itself.