### PR TITLE
fix(iife): try reading global declaration

### DIFF
--- a/lib/index.iife.js
+++ b/lib/index.iife.js
@@ -55,7 +55,7 @@
   }
   return VueDemi
 })(
-  this.VueDemi = this.VueDemi || {},
-  this.Vue,
-  this.VueCompositionAPI
+  this.VueDemi = this.VueDemi || (typeof VueDemi !== "undefined" ? VueDemi : {}),
+  this.Vue || (typeof Vue !== "undefined" ? Vue : undefined),
+  this.VueCompositionAPI || (typeof VueCompositionAPI !== "undefined" ? VueCompositionAPI : undefined)
 );


### PR DESCRIPTION
Sorry for the last problematic pr, but I still find myself needing to read the global-declared `Vue`, since no-window means no `this.Vue` so `vue-demi` is still in trouble trying to find a `Vue` instance.

For how I ran into this, the answer is UserScript `@require` tag, which doesn't have window access until the actual script is being executed.