### PR TITLE
docs: added remark about component libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ Publish your plugin and all is done!
 > })
 > ```
 
+### Remark
+
+`Vue Demi` is only supposed to work with libraries/plugins that use the `@vue/composition-api`, that are **not** components (e.g. `VueUse`, `Pinia`, ...). In other words, you can't use a `Vue3` compiled library in a `Vue2` project and vice versa, because they use different compilers.
+
+In order to build a component library/plugin for both `Vue2` and `Vue3` you could either publish plain `Vue` files or build your library seperately for `Vue2` and `Vue3`. Both options can be tricky because there are a few differences in their runtime APIs.
+
 ### Extra APIs
 
 `Vue Demi` provides extra APIs to help distinguish users' environments and to do some version-specific logic.


### PR DESCRIPTION
To avoid more issues about why a certain `Vue3` library/plugin failed to work in a `Vue2` project, I thought it would be useful to add it to the README.md.

I tried to add a more compact version of the answer @LinusBorg gave me on Discord (see #152).
