### PR TITLE
fix(2.7): ts compilation error

### DIFF
--- a/lib/v2.7/index.d.ts
+++ b/lib/v2.7/index.d.ts
@@ -1,4 +1,6 @@
-import type { PluginFunction, PluginObject } from 'vue'
+import Vue from 'vue'
+import type { PluginFunction, PluginObject, VueConstructor, VNode, VNodeDirective } from 'vue'
+
 declare const isVue2: boolean
 declare const isVue3: boolean
 declare const Vue2: Vue | undefined
@@ -16,8 +18,6 @@ export declare type Plugin = PluginObject<any> | PluginFunction<any>
 export type { VNode } from 'vue'
 export * from 'vue'
 export { V as Vue, Vue2, isVue2, isVue3, version, install }
-
-import Vue, { VueConstructor, VNode, VNodeDirective } from 'vue'
 
 // #region createApp polyfill
 export type DirectiveModifiers = Record<string, boolean>

--- a/lib/v2.7/index.d.ts
+++ b/lib/v2.7/index.d.ts
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import type { PluginFunction, PluginObject } from 'vue'
 declare const isVue2: boolean
 declare const isVue3: boolean


### PR DESCRIPTION
We need this fix so our Typescript projects that use this package can build properly.

There are duplicate Vue imports in this file.

![image](https://user-images.githubusercontent.com/5346661/178282015-ec49a781-95ec-4a5c-8379-463fd2aca0b8.png)
