### PR TITLE
chore: types when esm exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     ".": {
       "require": "./lib/index.cjs",
       "import": "./lib/index.mjs",
-      "browser": "./lib/index.mjs"
+      "browser": "./lib/index.mjs",
+      "types": "./lib/index.d.ts"
     },
     "./*": "./*"
   },


### PR DESCRIPTION
When using "moduleResolution": "node16" in tsconfig, the pinia doesn't get type definition.

I add the types field in exports with package.json. It works well.