### PR TITLE
fix(iife): createApp polyfill

### DIFF
--- a/lib/index.iife.js
+++ b/lib/index.iife.js
@@ -13,6 +13,45 @@
       VueDemi.Vue = Vue
       VueDemi.Vue2 = Vue
       VueDemi.version = Vue.version
+      function createApp(rootComponent, rootProps) {
+        var vm
+        var provide = {}
+        var app = {
+          config: Vue.config,
+          use: Vue.use.bind(Vue),
+          mixin: Vue.mixin.bind(Vue),
+          component: Vue.component.bind(Vue),
+          provide: function (key, value) {
+            provide[key] = value
+            return this
+          },
+          directive: function (name, dir) {
+            if (dir) {
+              Vue.directive(name, dir)
+              return app
+            } else {
+              return Vue.directive(name)
+            }
+          },
+          mount: function (el, hydrating) {
+            if (!vm) {
+              vm = new Vue(Object.assign({ propsData: rootProps }, rootComponent, { provide: Object.assign(provide, rootComponent.provide) }))
+              vm.$mount(el, hydrating)
+              return vm
+            } else {
+              return vm
+            }
+          },
+          unmount: function () {
+            if (vm) {
+              vm.$destroy()
+              vm = undefined
+            }
+          },
+        }
+        return app
+      }
+      VueDemi.createApp = createApp
     }
     else if (Vue.version.slice(0, 2) === '2.') {
       if (VueCompositionAPI) {


### PR DESCRIPTION
It would be useful to have `createApp` polyfill in vue-demi iife. For my use case, it’s useful in [testing for the Composition API using iife](https://github.com/intlify/vue-i18n-next/pull/1062/files#diff-83e7a30c07ab923ae44e2b18b9435c440d92da4f04183ee3bc1a7aa703a0a2cd).
