### PR TITLE
fix(<2.7): Install composition API on provided vue instance

### DIFF
--- a/lib/v2/index.mjs
+++ b/lib/v2/index.mjs
@@ -4,7 +4,7 @@ import VueCompositionAPI from '@vue/composition-api/dist/vue-composition-api.mjs
 function install(_vue) {
   _vue = _vue || Vue
   if (_vue && !_vue['__composition_api_installed__'])
-    Vue.use(VueCompositionAPI)
+    _vue.use(VueCompositionAPI)
 }
 
 install(Vue)


### PR DESCRIPTION
When calling `install(VueInstance)` in versions < 2.7 the composition API was always being installed in the same Vue instance.

Now it add the compositionAPI on the Vue instance provided by parameter to the install function.

fix https://github.com/vueuse/vue-demi/issues/184