### PR TITLE
feat: add warn to vue 2.7

### DIFF
--- a/lib/v2.7/index.cjs
+++ b/lib/v2.7/index.cjs
@@ -5,6 +5,7 @@ exports.Vue2 = Vue
 exports.isVue2 = true
 exports.isVue3 = false
 exports.install = function () {}
+exports.warn = Vue.util.warn
 
 // createApp polyfill
 exports.createApp = function (rootComponent, rootProps) {

--- a/lib/v2.7/index.d.ts
+++ b/lib/v2.7/index.d.ts
@@ -1,11 +1,12 @@
 import Vue from 'vue'
-import type { PluginFunction, PluginObject, VueConstructor, Directive, InjectionKey } from 'vue'
+import type { PluginFunction, PluginObject, VueConstructor, Directive, InjectionKey, Component } from 'vue'
 
 declare const isVue2: boolean
 declare const isVue3: boolean
 declare const Vue2: typeof Vue | undefined
 declare const version: string
 declare const install: (vue?: typeof Vue) => void
+export declare function warn(msg: string, vm?: Component | null): void
 /**
  * @deprecated To avoid bringing in all the tree-shakable modules, this API has been deprecated. Use `Vue2` or named exports instead.
  * Refer to https://github.com/vueuse/vue-demi/issues/41

--- a/lib/v2.7/index.mjs
+++ b/lib/v2.7/index.mjs
@@ -3,6 +3,7 @@ import Vue from 'vue'
 var isVue2 = true
 var isVue3 = false
 var Vue2 = Vue
+var warn = Vue.util.warn
 
 function install() {}
 
@@ -46,5 +47,5 @@ export function createApp(rootComponent, rootProps) {
   return app
 }
 
-export { Vue, Vue2, isVue2, isVue3, install }
+export { Vue, Vue2, isVue2, isVue3, install, warn }
 export * from 'vue'


### PR DESCRIPTION
Since `@vue/composition-api` and `vue@3` have a `warn` method that conveniently shows the Component stacktrace in errors, I think it should also be added to Vue 2.7. It avoid import warnings like

- https://github.com/posva/vue-promised/issues/394