### PR TITLE
fix: check default in CJS build

### DIFF
--- a/lib/index.iife.js
+++ b/lib/index.iife.js
@@ -58,7 +58,7 @@ var VueDemi = (function (VueDemi, Vue, VueCompositionAPI) {
       return app
     }
     VueDemi.createApp = createApp
-  } 
+  }
   // Vue 2.6.x
   else if (Vue.version.slice(0, 2) === '2.') {
     if (VueCompositionAPI) {

--- a/lib/v2.7/index.cjs
+++ b/lib/v2.7/index.cjs
@@ -1,4 +1,7 @@
-var Vue = require('vue')
+var VueModule = require('vue')
+
+// get the real Vue https://github.com/vueuse/vue-demi/issues/192
+var Vue = 'default' in VueModule ? VueModule.default : VueModule
 
 exports.Vue = Vue
 exports.Vue2 = Vue
@@ -47,6 +50,6 @@ exports.createApp = function (rootComponent, rootProps) {
   return app
 }
 
-Object.keys(Vue).forEach(function (key) {
-  exports[key] = Vue[key]
+Object.keys(VueModule).forEach(function (key) {
+  exports[key] = VueModule[key]
 })


### PR DESCRIPTION
Fix #192

It might happens because webpack doesn't respect the exports field