### PR TITLE
fix(<2.7): Install composition API on provided vue default instance

### DIFF
--- a/lib/v2/index.mjs
+++ b/lib/v2/index.mjs
@@ -4,7 +4,7 @@ import VueCompositionAPI from '@vue/composition-api/dist/vue-composition-api.mjs
 function install(_vue) {
   _vue = _vue || Vue
   if (_vue && !_vue['__composition_api_installed__'])
-    _vue.use(VueCompositionAPI)
+    _vue.default.use(VueCompositionAPI)
 }
 
 install(Vue)


### PR DESCRIPTION
I saw similar issue was fixed by this [commit](https://github.com/vueuse/vue-demi/commit/bde0b125ac8214c785c1ca54635f365aad8cc611) but it's still reproducible for me when I use `vue-apollo-composable` which has `vue-demi` as dependency.

![179224159-545a207d-c91d-42dc-94a7-4d967661d6fd](https://user-images.githubusercontent.com/3430069/222457263-c5c69a3f-3a91-40de-a7c5-e4d0fcc0b807.png)

![179224189-2c911de8-3919-4563-bf51-97fd828d0783](https://user-images.githubusercontent.com/3430069/222457279-9af497da-3fc2-4625-aba0-02915d3bef8a.png)

I changed code manually to `_vue.default.use(VueCompositionAPI)` and it worked for me. I think it can be a potential fix so send this MR.
