### PR TITLE
fix(<2.7): hasInjectionContext error

### DIFF
--- a/lib/v2/index.mjs
+++ b/lib/v2/index.mjs
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import VueCompositionAPI from '@vue/composition-api/dist/vue-composition-api.mjs'
+import VueCompositionAPI, { getCurrentInstance } from '@vue/composition-api/dist/vue-composition-api.mjs'
 
 function install(_vue) {
   _vue = _vue || Vue
@@ -45,5 +45,5 @@ export var KeepAlive = /*#__PURE__*/ createMockComponent('KeepAlive')
 
 // Not implemented https://github.com/vuejs/core/pull/8111, falls back to getCurrentInstance()
 export function hasInjectionContext() {
-  return !!VueCompositionAPI.getCurrentInstance()
+  return !!getCurrentInstance()
 }


### PR DESCRIPTION
VueCompositionAPI.getcurrentInstance is not a function