### PR TITLE
Re-export Options API needed type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -13,6 +13,7 @@ export function set<T>(target: any, key: any, val: T): T
 export function del(target: any, key: any): void
 
 export * from 'vue'
+export type { WatchOptions } from 'vue/types/v3-generated'
 export {
   V as Vue,
   Vue2,


### PR DESCRIPTION
fix https://github.com/vueuse/vueuse/issues/2232

Please adjust if importing from `v3-generated` is a bad practice, but the ticket has been opened for too long, and stale-bot is a bit too fast.