### PR TITLE
fix(scripts): fix error in install

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "scripts"
   ],
   "scripts": {
-    "postinstall": "node ./scripts/postinstall.js",
+    "postinstall": "node -e \"try{require('./scripts/postinstall.js')}catch(e){}\"",
     "release": "npx bumpp --tag --commit --push && npm publish"
   },
   "peerDependencies": {


### PR DESCRIPTION
Insufficient installation directory permissions can cause script execution to fail

在某些环境中，postinstall文件可能执行权限不足，而postinstall命令无容错处理可能会导致安装环节报错，影响整体流程。