### PR TITLE
feat: support `<script type="module" src"...">`

### DIFF
--- a/lib/index.iife.js
+++ b/lib/index.iife.js
@@ -113,7 +113,7 @@ var VueDemi = (function (VueDemi, Vue, VueCompositionAPI) {
   }
   return VueDemi
 })(
-  (this.VueDemi = this.VueDemi || (typeof VueDemi !== 'undefined' ? VueDemi : {})),
-  this.Vue || (typeof Vue !== 'undefined' ? Vue : undefined),
-  this.VueCompositionAPI || (typeof VueCompositionAPI !== 'undefined' ? VueCompositionAPI : undefined)
+  ((globalThis || self).VueDemi = (globalThis || self).VueDemi || (typeof VueDemi !== 'undefined' ? VueDemi : {})),
+  (globalThis || self).Vue || (typeof Vue !== 'undefined' ? Vue : undefined),
+  (globalThis || self).VueCompositionAPI || (typeof VueCompositionAPI !== 'undefined' ? VueCompositionAPI : undefined)
 );


### PR DESCRIPTION
I want to use vue-demi through `<script type="module" src"..."></script>`