### PR TITLE
Skip postinstall script in Deno

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "scripts"
   ],
   "scripts": {
-    "postinstall": "node -e \"try{require('./scripts/postinstall.js')}catch(e){}\"",
+    "postinstall": "which node > /dev/null && node -e \"try{require('./scripts/postinstall.js')}catch(e){}\"",
     "release": "npx bumpp --tag --commit --push && npm publish"
   },
   "peerDependencies": {


### PR DESCRIPTION
Skip postinstall script if `node` is not in the path, which may be the case if only `deno` is used (such as in CI).

Currently it is causing an error as mentioned here: https://github.com/denoland/deno/issues/21110#issuecomment-2271861789

```
Error launching 'node': No such file or directory (os error 2)
error: script 'postinstall' in 'vue-demi@0.14.7' failed with exit code 1
Cleaning up project directory and file based variables
00:01
ERROR: Job failed: exit code 1
```

This prevents vitepress from working on Deno.