### PR TITLE
chore: deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 
 <br>
 
+> [!CAUTION]
+> `vue-demi` should not be used for new projects and will be deprecated in the future.
+
 <br>
 
 ## Strategies


### PR DESCRIPTION
Due to type differences in Vue 2 and Vue 3, plus EOL of Vue 2 of almost a year, @antfu plans to stop maintaining `vue-demi`.
This message makes it "official".

![image](https://github.com/user-attachments/assets/3321b891-83af-4051-926f-9a98168edf63)

[Further info](https://bsky.app/profile/esm.dev/post/3lbfkbqugnc2n)