### PR TITLE
Add side effects to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "jsdelivr": "lib/index.iife.js",
   "unpkg": "lib/index.iife.js",
   "module": "lib/index.mjs",
+  "sideEffects": false,
   "types": "lib/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
Add side effects to package.json, help bundlers cut unused code via treeshake. Good with esm, modules, named imports.